### PR TITLE
fixing vulnerability

### DIFF
--- a/access/service.py
+++ b/access/service.py
@@ -1,15 +1,11 @@
 from datetime import datetime, timedelta
 from django.utils import timezone
+import django_get_ip
 from .models import Access
 
 
 def get_client_ip(request):
-    x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
-    if x_forwarded_for:
-        ip = x_forwarded_for.split(',')[0]
-    else:
-        ip = request.META.get('REMOTE_ADDR')
-    return ip
+    return str(django_get_ip.get_client_ip(request))
 
 
 def get_access_status(request):

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ django-allauth==0.56.1
 django-ckeditor==6.7.0
 django-cors-headers==4.2.0
 django-debug-toolbar==4.2.0
+django-get-ip==2.310
 django-js-asset==2.1.0
 django-redis==5.3.0
 frozenlist==1.4.0


### PR DESCRIPTION
The code has the ability to spoof an IP address associated with the `X-Forwarded-For` header.
Example of exploit:
```bash
curl -H "X-Forwarded-For: 1.1.1.1" https://easyoffer.ru/Jljo0U9Erg7QDtkb133G7vzDexHVw6Iz
```